### PR TITLE
Export the `CanvasKit` type

### DIFF
--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./c2d";
 
 export * from "./CanvasKit";
+export type { CanvasKit };
 
 declare global {
   interface Window {


### PR DESCRIPTION
Convienient to make not have type errors

```
declare global {
	interface Window {
		CanvasKit: CanvasKit;
	}
}
```